### PR TITLE
fix: ios sync does not bump version when all cities fail

### DIFF
--- a/apps/iphone/Bönetider/Domain/PrayerTimeData.swift
+++ b/apps/iphone/Bönetider/Domain/PrayerTimeData.swift
@@ -127,19 +127,27 @@ class PrayerTimeRepository: ObservableObject {
   }
 
   private func syncAllPrayerTimes(version: String) async throws {
+    var anySucceeded = false
     for method in PrayerTimeMethod.allCases {
       for city in PrayerTimeCity.allCases {
         do {
           try await fetchAndSaveTimes(method: method, city: city)
+          anySucceeded = true
         } catch {
           print(">> PrayerTimeRepository: Failed to fetch for \(city.rawValue) - \(method.rawValue)")
         }
       }
     }
+
+    guard anySucceeded else {
+      print(">> PrayerTimeRepository: No cities synced, keeping existing version.")
+      return
+    }
+
     UserDefaults.standard.set(version, forKey: lastUpdatedKey)
     PrayerTimeData.clearCache()
-    print(">> PrayerTimeRepository: Successfully synced all times.")
-    
+    print(">> PrayerTimeRepository: Successfully synced prayer times (\(version)).")
+
     await MainActor.run {
       NotificationCenter.default.post(name: NSNotification.Name("PrayerTimesUpdated"), object: nil)
     }


### PR DESCRIPTION
- Track whether any per-city fetch succeeded in PrayerTimeRepository.syncAllPrayerTimes.
- On total failure, skip UserDefaults update, cache clear, and UI notification so the next sync retries.
- Matches Android's 'only bump on at least one success' behavior in PrayerTimeRepository.syncAllPrayerTimes.